### PR TITLE
Update to LH2 config

### DIFF
--- a/Patches/CryoTanks.cfg
+++ b/Patches/CryoTanks.cfg
@@ -1,9 +1,9 @@
 //by TheRedTom
 
-@PART[CA_STME]:NEEDS[CryoEngines]{
+@PART[CA_STME]:NEEDS[CryoTanks]{
 @description = Further development of the KS-25 brought about this cheaper and lighter hydrogen powered engine.
 
-!MODULE[ModuleEnginesFX]
+!MODULE[ModuleEnginesFX]{}
 	MODULE
 	{
 		name = ModuleEnginesFX
@@ -39,9 +39,9 @@
 	}
 }
 
-@PART[SSME]:NEEDS[CryoEngines]{
+@PART[SSME]:NEEDS[CryoTanks]{
 
-!MODULE[ModuleEnginesFX]
+!MODULE[ModuleEnginesFX]{}
 	MODULE
 	{
 		name = ModuleEnginesFX


### PR DESCRIPTION
Spotted and fixed the MM error that caused both Lh2 and LFO modes to exist simultaneously in the STME and Squad SSME. This is also what caused the plume breakage with real plume.
The original patch intended to delete the old LFO engine module but the curly brackets were missing.

Changed NEEDS to CryoTanks instead of CryoEngines as CT is the mod that provides the LH2 tank switcher