### PR TITLE
RealPlume fixes for OMS engines

### DIFF
--- a/Patches/RealPlumes/OMSEngine.cfg
+++ b/Patches/RealPlumes/OMSEngine.cfg
@@ -11,11 +11,10 @@
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-        flarePosition = 0,0,0.74
+        flarePosition = 0,0,-0.05
         plumePosition = 0,0,0
         fixedScale = 0.75
         energy = 1
         speed = 1
     }
 }
-

--- a/Patches/RealPlumes/OMSEngineA.cfg
+++ b/Patches/RealPlumes/OMSEngineA.cfg
@@ -11,11 +11,10 @@
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-        flarePosition = 0,0,0.74
+        flarePosition = 0,0,-0.05
         plumePosition = 0,0,0
         fixedScale = 0.75
         energy = 1
         speed = 1
     }
 }
-


### PR DESCRIPTION
The flare effect is away from the engine bell by several meters. This adjustment fixes it.